### PR TITLE
Changed config to load from dedicated manifest.json file.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,11 @@ module.exports = function (gulp) {
   const fs = require('fs');
   const path = require('path');
   const tasksPath = path.join(__dirname, 'tasks');
-  const pkg = require(path.resolve('package.json'));
+  const config = require(path.resolve('manifest.json')).config;
   const $ = require('gulp-load-plugins')();
   // Manually add required plugins to $ plugins object.
   $.del = require('del');
+  $.path = require('path');
   $.sassModuleImporter = require('sass-module-importer');
 
   const tasks = [
@@ -21,6 +22,6 @@ module.exports = function (gulp) {
     'default',
   ];
   for (let task of tasks) {
-    require('./tasks/' + task)(gulp, $, pkg);
+    require('./tasks/' + task)(gulp, $, config);
   }
 };

--- a/package.json
+++ b/package.json
@@ -31,35 +31,6 @@
     "stylelint-scss": "^2.2.0",
     "stylelint-selector-bem-pattern": "^2.0.0"
   },
-  "browserslist": [
-    "last 2 versions",
-    "ie 8",
-    "ie 9",
-    "android 2.3",
-    "android 4",
-    "opera 12"
-  ],
-  "gulpPaths": {
-    "destDir": "./dist",
-    "images": {
-      "src": "./assets/img/**/*.{jpg,jpeg,png,gif,svg}",
-      "dest": "./dist/img"
-    },
-    "scripts": {
-      "src": "./components/**/*.js",
-      "dest": "./dist/js"
-    },
-    "styleguide": "styleguide",
-    "styles": {
-      "srcDir": "./assets/scss",
-      "src": [
-        "./assets/scss/**/*.scss",
-        "./components/**/*.scss"
-      ],
-      "dest": "./dist/css"
-    },
-    "templates": "./templates/**/*.twig"
-  },
   "scripts": {
     "test": "mocha"
   },

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = (gulp, $, pkg) => {
+module.exports = (gulp, $, config) => {
   // @task: Build and minify all static assets.
   gulp.task('build', gulp.series('clean', gulp.parallel(
     'images',

--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -1,8 +1,8 @@
 'use strict';
 
-module.exports = (gulp, $, pkg) => {
+module.exports = (gulp, $, config) => {
   // @task: Delete /dist directory.
-  const task = () => $.del(pkg.gulpPaths.destDir);
+  const task = () => $.del(config.paths.destDir);
 
   gulp.task('clean', task);
 }

--- a/tasks/default.js
+++ b/tasks/default.js
@@ -1,13 +1,13 @@
 'use strict';
 
-module.exports = (gulp, $, pkg) => {
+module.exports = (gulp, $, config) => {
   // @task: Watch files for changes and reload.
   const watch = (callback) => {
     // Fractal automatically detects existing server instance.
     $.livereload.listen();
-    gulp.watch(pkg.gulpPaths.styles.src, gulp.series('styles'));
-    gulp.watch(pkg.gulpPaths.scripts.src, gulp.series('scripts'));
-    gulp.watch(pkg.gulpPaths.templates, (files) => {
+    gulp.watch(config.paths.styles.src, gulp.series('styles'));
+    gulp.watch(config.paths.scripts.src, gulp.series('scripts'));
+    gulp.watch(config.paths.templates, (files) => {
       $.livereload.changed(files);
     });
     callback(); // Required to stop Gulp throwing async competion error.

--- a/tasks/fractal.js
+++ b/tasks/fractal.js
@@ -1,8 +1,7 @@
 'use strict';
 
-module.exports = (gulp, $, pkg) => {
-  const path = require('path');
-  const fractal = require(path.resolve(pkg.fractalConfigPath));
+module.exports = (gulp, $, config) => {
+  const fractal = require($.path.resolve(config.paths.fractal));
   // @task: Start Fractal server.
   start: {
     const task = () => {

--- a/tasks/images.js
+++ b/tasks/images.js
@@ -1,16 +1,16 @@
 'use strict';
 
-module.exports = (gulp, $, pkg) => {
+module.exports = (gulp, $, config) => {
   // @task: Process and minify images.
   const task = () => {
-    return gulp.src(pkg.gulpPaths.images.src)
+    return gulp.src(config.paths.images.src)
       .pipe($.imagemin([
         $.imagemin.gifsicle({ interlaced: true }),
         $.imagemin.jpegtran({ progressive: true }),
         $.imagemin.optipng({ optimizationLevel: 5 }),
         $.imagemin.svgo({ plugins: [{ cleanupIDs: false }] })
       ]))
-      .pipe(gulp.dest(pkg.gulpPaths.images.dest));
+      .pipe(gulp.dest($.path.join(config.paths.destDir, config.paths.images.dest)));
   };
 
   gulp.task('images', task);

--- a/tasks/scripts.js
+++ b/tasks/scripts.js
@@ -1,16 +1,17 @@
 'use strict';
 
-module.exports = (gulp, $, pkg) => {
+module.exports = (gulp, $, config) => {
+  const pkg = require($.path.resolve('./package.json'));
   // @task: Build JS from components.
   const task = (options = {}) => {
-    return gulp.src(pkg.gulpPaths.scripts.src)
+    return gulp.src(config.paths.scripts.src)
       .pipe($.plumber())
       .pipe($.if(options.sourcemaps, $.sourcemaps.init()))
       .pipe($.concat(pkg.title.toLowerCase().replace(/[^a-z]/g,'') + '.js'))
       .pipe($.if(options.sourcemaps, $.sourcemaps.write()))
       .pipe($.if(options.production, $.uglifyEs.default()))
       .pipe($.if(options.production, $.rename({ suffix: '.min' })))
-      .pipe(gulp.dest(pkg.gulpPaths.scripts.dest))
+      .pipe(gulp.dest($.path.join(config.paths.destDir, config.paths.scripts.dest)))
       .pipe($.livereload());
   };
 

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -1,6 +1,7 @@
 'use strict';
 
-module.exports = (gulp, $, pkg) => {
+module.exports = (gulp, $, config) => {
+  const pkg = require($.path.resolve('./package.json'));
   const reportError = require('../lib/error.js');
 
   // Copyright notice placed at top of compiled CSS
@@ -24,7 +25,7 @@ module.exports = (gulp, $, pkg) => {
 
   // @task: Build Sass styles from components.
   const task = (options = {}) => {
-    return gulp.src(pkg.gulpPaths.styles.src, { base: pkg.gulpPaths.styles.srcDir })
+    return gulp.src(config.paths.styles.src, { base: config.paths.styles.srcDir })
       .pipe($.plumber())
       .pipe($.stylelint({
         syntax: 'scss',
@@ -44,7 +45,7 @@ module.exports = (gulp, $, pkg) => {
       .pipe($.if(options.production, $.replace(copyrightPlaceholder, copyrightNotice)))
       .pipe($.if(options.production, $.cleanCss(cleanCssOptions)))
       .pipe($.if(options.production, $.rename({ suffix: '.min' })))
-      .pipe(gulp.dest(pkg.gulpPaths.styles.dest))
+      .pipe(gulp.dest($.path.join(config.paths.destDir, config.paths.styles.dest)))
       .pipe($.livereload());
   };
 


### PR DESCRIPTION
**Intention:**
The config settings "pollute" the `package.json` and should rather be extracted to a dedicated (`manifest.json`) file.

The `manifest.json` is placed in the main project directory. I also thought of having a default `manifest.json` in the module directory. Keys are then getting overwritten from the main project's `mainfest.json` file so the main file will also be rather slim. Since the merging, through it's nesting and stuff, is a bit more complex (and also I don't know if really necessary), this PR contains the basic change.

See demo `manifest.json`

```json
{
  "config": {
    "browserslist": [
      "last 2 versions",
      "ie 8",
      "ie 9",
      "android 2.3",
      "android 4",
      "opera 12"
    ],
    "paths": {
      "styleguide": "styleguide",
      "fractal": "./fractal.config.js",
      "templates": "./templates/**/*.twig",
      "destDir": "./dist",
      "images": {
        "src": "./assets/img/**/*.{jpg,jpeg,png,gif,svg}",
        "dest": "img"
      },
      "scripts": {
        "src": "./components/**/*.js",
        "dest": "js"
      },
      "styles": {
        "srcDir": "./assets/scss",
        "src": [
          "./assets/scss/**/*.scss",
          "./components/**/*.scss"
        ],
        "dest": "css"
      }
    }
  }
}
```