### PR TITLE
Added support for CLI arguments.

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ module.exports = function (gulp) {
   const $ = require('gulp-load-plugins')();
   // Manually add required plugins to $ plugins object.
   $.del = require('del');
+  $.minimist = require('minimist');
+  $.path = require('path');
   $.sassModuleImporter = require('sass-module-importer');
 
   const tasks = [

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "opera 12"
   ],
   "gulpPaths": {
-    "fractalConfigFilePath": "./fractal.config.js",
+    "fractalConfig": "./fractal.config.js",
     "destDir": "./dist",
     "images": {
       "src": "./assets/img/**/*.{jpg,jpeg,png,gif,svg}",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "opera 12"
   ],
   "gulpPaths": {
-    "fractalConfigPath": "./fractal.config.js",
+    "fractalConfigFilePath": "./fractal.config.js",
     "destDir": "./dist",
     "images": {
       "src": "./assets/img/**/*.{jpg,jpeg,png,gif,svg}",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "gulp-replace": "^0.6.1",
     "gulp-sass": "~3.1.0",
     "gulp-sass-glob": "^1.0.8",
-    "gulp-sass-glob": "^1.0.8",
     "gulp-sourcemaps": "^2.6.0",
     "gulp-stylelint": "^6.0.0",
     "gulp-uglify-es": "^0.1.4",
+    "minimist": "^1.2.0",
     "sass-module-importer": "^1.4.0",
     "sassdoc": "^2.3.0",
     "stylelint": "^8.4.0",
@@ -40,6 +40,7 @@
     "opera 12"
   ],
   "gulpPaths": {
+    "fractalConfigPath": "./fractal.config.js",
     "destDir": "./dist",
     "images": {
       "src": "./assets/img/**/*.{jpg,jpeg,png,gif,svg}",

--- a/tasks/fractal.js
+++ b/tasks/fractal.js
@@ -2,7 +2,7 @@
 
 module.exports = (gulp, $, pkg) => {
   const path = require('path');
-  const fractal = require(path.resolve(pkg.gulpPaths.fractalConfigFilePath));
+  const fractal = require(path.resolve(pkg.gulpPaths.fractalConfig));
   // @task: Start Fractal server.
   start: {
     const task = () => {

--- a/tasks/fractal.js
+++ b/tasks/fractal.js
@@ -2,7 +2,7 @@
 
 module.exports = (gulp, $, pkg) => {
   const path = require('path');
-  const fractal = require(path.resolve(pkg.gulpPaths.fractalConfigPath));
+  const fractal = require(path.resolve(pkg.gulpPaths.fractalConfigFilePath));
   // @task: Start Fractal server.
   start: {
     const task = () => {

--- a/tasks/fractal.js
+++ b/tasks/fractal.js
@@ -2,7 +2,7 @@
 
 module.exports = (gulp, $, pkg) => {
   const path = require('path');
-  const fractal = require(path.resolve(pkg.fractalConfigPath));
+  const fractal = require(path.resolve(pkg.gulpPaths.fractalConfigPath));
   // @task: Start Fractal server.
   start: {
     const task = () => {

--- a/tasks/scripts.js
+++ b/tasks/scripts.js
@@ -2,11 +2,15 @@
 
 module.exports = (gulp, $, pkg) => {
   // @task: Build JS from components.
-  const task = (options = {}) => {
+  const task = (args = {}) => {
+    const options = Object.assign($.minimist(process.argv.slice(2), {
+      boolean: ['concat', 'sourcemaps', 'production'],
+      default: { concat: true },
+    }), args);
     return gulp.src(pkg.gulpPaths.scripts.src)
       .pipe($.plumber())
       .pipe($.if(options.sourcemaps, $.sourcemaps.init()))
-      .pipe($.concat(pkg.title.toLowerCase().replace(/[^a-z]/g,'') + '.js'))
+      .pipe($.if(options.concat, $.concat(pkg.title.toLowerCase().replace(/[^a-z]/g,'') + '.js')))
       .pipe($.if(options.sourcemaps, $.sourcemaps.write()))
       .pipe($.if(options.production, $.uglifyEs.default()))
       .pipe($.if(options.production, $.rename({ suffix: '.min' })))

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -23,7 +23,12 @@ module.exports = (gulp, $, pkg) => {
   };
 
   // @task: Build Sass styles from components.
-  const task = (options = {}) => {
+  const task = (args) => {
+    const options = Object.assign($.minimist(process.argv.slice(2), {
+      string: ['outputStyle'],
+      boolean: ['concat', 'sourcemaps', 'production'],
+      default: { concat: true },
+    }), args);
     return gulp.src(pkg.gulpPaths.styles.src, { base: pkg.gulpPaths.styles.srcDir })
       .pipe($.plumber())
       .pipe($.stylelint({
@@ -33,13 +38,13 @@ module.exports = (gulp, $, pkg) => {
           console: true
         }]
       }))
-      .pipe($.concat(pkg.title.toLowerCase().replace(/[^a-z]/g,'') + '.scss'))
+      .pipe($.if(options.concat, $.concat(pkg.title.toLowerCase().replace(/[^a-z]/g,'') + '.scss')))
       .pipe($.if(options.sourcemaps, $.sourcemaps.init()))
       .pipe($.sass({
         importer: $.sassModuleImporter(),
         outputStyle: options.outputStyle
       }).on('error', reportError))
-      .pipe($.autoprefixer(pkg.browserslist))
+      .pipe($.autoprefixer())
       .pipe($.if(options.sourcemaps, $.sourcemaps.write()))
       .pipe($.if(options.production, $.replace(copyrightPlaceholder, copyrightNotice)))
       .pipe($.if(options.production, $.cleanCss(cleanCssOptions)))


### PR DESCRIPTION
This PR adds support for passing arguments via the CLI. I introduced this to get more flexibility when running tasks. For example, sometimes you don't want to concatenate the CSS files. 

Example:
```bash
# Add argument to all tasks
$ gulp --concat false
# Add argument to specific task only
$ gulp styles --concat false
$ gulp scripts --sourcemaps --production --concat false
```

In addition to this, we can also integrate support for setting such arguments from the `package.json`. The order would then be (low to high priority):

1. defaults from the task declaration itself
2. arguments in `package.json` 
3. CLI arguments