### PR TITLE
Fixed `gulp build` does not generate unminified/unoptimized CSS/JS files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netzstrategen/gulp-task-collection",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "title": "Gulp task collection",
   "description": "A collection of gulp tasks.",
   "main": "index.js",

--- a/tasks/scripts.js
+++ b/tasks/scripts.js
@@ -12,6 +12,7 @@ module.exports = (gulp, $, pkg) => {
       .pipe($.if(options.sourcemaps, $.sourcemaps.init()))
       .pipe($.if(options.concat, $.concat(pkg.title.toLowerCase().replace(/[^a-z]/g,'') + '.js')))
       .pipe($.if(options.sourcemaps, $.sourcemaps.write()))
+      .pipe(gulp.dest(pkg.gulpPaths.scripts.dest))
       .pipe($.if(options.production, $.uglifyEs.default()))
       .pipe($.if(options.production, $.rename({ suffix: '.min' })))
       .pipe(gulp.dest(pkg.gulpPaths.scripts.dest))

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -46,6 +46,7 @@ module.exports = (gulp, $, pkg) => {
       }).on('error', reportError))
       .pipe($.autoprefixer())
       .pipe($.if(options.sourcemaps, $.sourcemaps.write()))
+      .pipe(gulp.dest(pkg.gulpPaths.styles.dest))
       .pipe($.if(options.production, $.replace(copyrightPlaceholder, copyrightNotice)))
       .pipe($.if(options.production, $.cleanCss(cleanCssOptions)))
       .pipe($.if(options.production, $.rename({ suffix: '.min' })))


### PR DESCRIPTION
Problem
* When running `gulp build` to set up a new instance of an existing project (e.g. during a deployment process), then only minified/optimized files are generated, causing 404 errors and a broken front-end in case the application searches for unminified files.

Goal
* Simplify project setup and deployment processes.

Proposed solution
1. Always write out the generated unminified/unoptimized files before the content is (potentially) minified/optimized.

Notes
* Having the unminified files in production is not a problem; they're simply not used.

* For `production: false` this simple fix causes a double write to the same file, which can be optimized in the future, but does not present a problem right now.