### PR TITLE
Added images are not build in default task.

### DIFF
--- a/tasks/default.js
+++ b/tasks/default.js
@@ -5,6 +5,7 @@ module.exports = (gulp, $, pkg) => {
   const watch = (callback) => {
     // Fractal automatically detects existing server instance.
     $.livereload.listen();
+    gulp.watch(pkg.gulpPaths.images.src, gulp.series('images'));
     gulp.watch(pkg.gulpPaths.styles.src, gulp.series('styles'));
     gulp.watch(pkg.gulpPaths.scripts.src, gulp.series('scripts'));
     gulp.watch(pkg.gulpPaths.templates, (files) => {
@@ -16,6 +17,7 @@ module.exports = (gulp, $, pkg) => {
   // @task: Default. Start Fractal and watch for changes.
   gulp.task('default', gulp.series(gulp.parallel(
     'fractal:start',
+    'images',
     'styles',
     'scripts'
   ), watch));


### PR DESCRIPTION
**Problem**
Images are not build when running `$ gulp` which needs to ether run `$ gulp build` or `$ gulp images` directly.

**Goal**
Run the `images` task when calling the default gulp task and watch the configured image directory.
