### PR TITLE
Fixed missing fractal module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "description": "A collection of gulp tasks.",
   "main": "index.js",
   "dependencies": {
+    "@frctl/fractal": "^1.1.7",
+    "@frctl/twig": "git+ssh://git@github.com:netzstrategen/twig-drupal.git",
     "del": "^3.0.0",
     "gulp": "^4.0.0",
     "gulp-autoprefixer": "^4.0.0",


### PR DESCRIPTION
**Problem**
The `default` gulp task requires the fractal module which is not set in the dependencies which breaks `$ gulp`. Those modules were defined by the theme until now.

**Goal**
Resolve missing dependencies and add require modules from this module rather the theme which includes the task collection.