### PR TITLE
Tidied tasks, made Fractal optional (via config), added docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# netzstrategen Gulp tasks collection
+
+Commonly used Gulp tasks shared across projects.
+
+## Supported tasks
+
+- Clean `/dist` folder
+- Sass compilation
+- JS compilation
+- Image compression
+- Fractal server and build
+
+## Installation
+
+1. `yarn add @netzstrategen/gulp-task-collection`
+2. `require` in project Gulpfile (see [sample.gulpfile.js](https://github.com/netzstrategen/gulp-task-collection/blob/master/sample.gulpfile.js))
+3. Customise asset paths in project `package.json` (see [package.json](https://github.com/netzstrategen/gulp-task-collection/blob/master/package.json))
+
+## Available commands
+
+- `gulp`: Default task runs (in order) `fractal:start`, `images`, `styles`, `scripts` and then watches for changes
+- `gulp build`: Build assets (`images`, `styles`, `scripts`)
+- `gulp build:production`: Build production-ready assets
+
+
+- `gulp clean`: Clean `/dist` folder
+- `gulp styles` and `gulp styles:production`: Sass compilation
+- `gulp scripts` and `gulp scripts:production`: JS compilation
+- `gulp images`: Image compression
+- `gulp fractal:start`: Start Fractal server (if config path exists in `package.json`)
+- `gulp fractal:build`: Build static version of Fractal project
+
+## Authors
+
+- Fabian Marz: [fabian@netzstrategen.com](fabian@netzstrategen.com)
+- Tom Hare: [tom@netzstrategen.com](tom@netzstrategen.com)

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 module.exports = function (gulp) {
   const fs = require('fs');
   const path = require('path');
-  const tasksPath = path.join(__dirname, 'tasks');
   const pkg = require(path.resolve('package.json'));
   const $ = require('gulp-load-plugins')();
   // Manually add required plugins to $ plugins object.
@@ -12,16 +11,17 @@ module.exports = function (gulp) {
   $.path = require('path');
   $.sassModuleImporter = require('sass-module-importer');
 
-  const tasks = [
+  let tasks = [
     'clean',
+    typeof(pkg.gulpPaths.fractalConfig) === 'undefined' ? '' : 'fractal',
     'fractal',
     'images',
     'scripts',
     'styles',
-    // Tasks have to come last
     'build',
     'default',
   ];
+  tasks = tasks.filter(Boolean);
   for (let task of tasks) {
     require('./tasks/' + task)(gulp, $, pkg);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netzstrategen/gulp-task-collection",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "title": "Gulp task collection",
   "description": "A collection of gulp tasks.",
   "main": "index.js",

--- a/sample.gulpfile.js
+++ b/sample.gulpfile.js
@@ -1,0 +1,8 @@
+/**
+ * Sample gulpfile.
+ * Gulp tasks declared in the gulp-task-collection module.
+ * Asset paths set in package.json.
+ */
+
+const gulp = require('gulp');
+require('@netzstrategen/gulp-task-collection')(gulp);

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -1,10 +1,17 @@
 'use strict';
 
 module.exports = (gulp, $, pkg) => {
-  // @task: Build and minify all static assets.
+  // @task: Build all static assets.
   gulp.task('build', gulp.series('clean', gulp.parallel(
     'images',
-    'scripts:build',
-    'styles:build'
+    'scripts',
+    'styles'
+  )));
+
+  // @task: Build and minify all static assets.
+  gulp.task('build:production', gulp.series('clean', gulp.parallel(
+    'images',
+    'scripts:production',
+    'styles:production'
   )));
 }

--- a/tasks/default.js
+++ b/tasks/default.js
@@ -14,11 +14,14 @@ module.exports = (gulp, $, pkg) => {
     callback(); // Required to stop Gulp throwing async competion error.
   };
 
-  // @task: Default. Start Fractal and watch for changes.
-  gulp.task('default', gulp.series(gulp.parallel(
-    'fractal:start',
+  let defaultTasks = [
+    typeof(pkg.gulpPaths.fractalConfig) === 'undefined' ? '' : 'fractal:start',
     'images',
     'styles',
     'scripts'
-  ), watch));
+  ];
+  defaultTasks = defaultTasks.filter(Boolean);
+
+  // @task: Default. Start Fractal and watch for changes.
+  gulp.task('default', gulp.series(gulp.parallel(defaultTasks), watch));
 }

--- a/tasks/scripts.js
+++ b/tasks/scripts.js
@@ -12,7 +12,6 @@ module.exports = (gulp, $, pkg) => {
       .pipe($.if(options.sourcemaps, $.sourcemaps.init()))
       .pipe($.if(options.concat, $.concat(pkg.title.toLowerCase().replace(/[^a-z]/g,'') + '.js')))
       .pipe($.if(options.sourcemaps, $.sourcemaps.write()))
-      .pipe(gulp.dest(pkg.gulpPaths.scripts.dest))
       .pipe($.if(options.production, $.uglifyEs.default()))
       .pipe($.if(options.production, $.rename({ suffix: '.min' })))
       .pipe(gulp.dest(pkg.gulpPaths.scripts.dest))
@@ -20,7 +19,7 @@ module.exports = (gulp, $, pkg) => {
   };
 
   gulp.task('scripts', task);
-  gulp.task('scripts:build', () => task({
+  gulp.task('scripts:production', () => task({
     sourcemaps: false,
     production: true,
   }));

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -46,7 +46,6 @@ module.exports = (gulp, $, pkg) => {
       }).on('error', reportError))
       .pipe($.autoprefixer())
       .pipe($.if(options.sourcemaps, $.sourcemaps.write()))
-      .pipe(gulp.dest(pkg.gulpPaths.styles.dest))
       .pipe($.if(options.production, $.replace(copyrightPlaceholder, copyrightNotice)))
       .pipe($.if(options.production, $.cleanCss(cleanCssOptions)))
       .pipe($.if(options.production, $.rename({ suffix: '.min' })))
@@ -55,7 +54,7 @@ module.exports = (gulp, $, pkg) => {
   };
 
   gulp.task('styles', task);
-  gulp.task('styles:build', () => task({
+  gulp.task('styles:production', () => task({
     outputStyle: 'compressed',
     sourcemaps: false,
     production: true,


### PR DESCRIPTION
We now have `gulp build` to quickly build assets and `gulp build:production` for when we finally get Scrutinzer working and can use Git deploy hooks!

Introduced a check where the Fractal task won't be registered or run if the config is missing from `package.json`. So if we're not using Fractal for a project then all we have to do is remove the config.

Not all that happy with the way the check is performed and it's repeated in the default task but I can't think of a way to do it without some major structural changes.