### PR TITLE
Changed npm import to allow for multiple output files.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function (gulp) {
   $.del = require('del');
   $.minimist = require('minimist');
   $.path = require('path');
-  $.sassModuleImporter = require('sass-module-importer');
+  $.magicImporter = require('node-sass-magic-importer');
 
   let tasks = [
     'clean',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netzstrategen/gulp-task-collection",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "title": "Gulp task collection",
   "description": "A collection of gulp tasks.",
   "main": "index.js",
@@ -27,7 +27,7 @@
     "gulp-stylelint": "^6.0.0",
     "gulp-uglify-es": "^0.1.4",
     "minimist": "^1.2.0",
-    "sass-module-importer": "^1.4.0",
+    "node-sass-magic-importer": "^5.2.0",
     "sassdoc": "^2.3.0",
     "stylelint": "^8.4.0",
     "stylelint-order": "^0.8.0",

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -26,8 +26,8 @@ module.exports = (gulp, $, pkg) => {
   const task = (args) => {
     const options = Object.assign($.minimist(process.argv.slice(2), {
       string: ['outputStyle'],
-      boolean: ['concat', 'sourcemaps', 'production'],
-      default: { concat: true },
+      boolean: ['sourcemaps', 'production'],
+      default: { },
     }), args);
     return gulp.src(pkg.gulpPaths.styles.src, { base: pkg.gulpPaths.styles.srcDir })
       .pipe($.plumber())
@@ -38,10 +38,11 @@ module.exports = (gulp, $, pkg) => {
           console: true
         }]
       }))
-      .pipe($.if(options.concat, $.concat(pkg.title.toLowerCase().replace(/[^a-z]/g,'') + '.scss')))
       .pipe($.if(options.sourcemaps, $.sourcemaps.init()))
       .pipe($.sass({
-        importer: $.sassModuleImporter(),
+        importer: $.magicImporter({
+          disableImportOnce: true
+        }),
         outputStyle: options.outputStyle
       }).on('error', reportError))
       .pipe($.autoprefixer())


### PR DESCRIPTION
Previous `node_modules` import plugin required concatenation of Sass files first.
As a result, only one compiled CSS output was ever allowed.
New plugin allows globbing in Sass files (rather than concatenating all paths listed in `package.json`).

@LucaPipolo Could you please test this on the shop or somewhere else where you're using the gulp-task-collection package? Please add a second source file (`luca.scss` alongside `nepo.scss`, for example).

You may need to update your `package.json` if you had multiple paths under `src`. For example:

**Previous:**
*package.json*
```
"src": [
  "./assets/scss/**/*.scss",
  "../../shared/nepo/components/1-atoms/**/*.scss",
  "../../shared/nepo/components/2-molecules/**/*.scss",
  "../../shared/nepo/components/3-organisms/**/*.scss",
  "../../shared/nepo/components/4-templates/**/*.scss",
  "../../shared/nepo/components/**/*.scss",
  "./components/1-atoms/**/*.scss",
  "./components/2-molecules/**/*.scss",
  "./components/3-organisms/**/*.scss",
  "./components/4-templates/**/*.scss",
  "./components/**/*.scss"
],
```

**New:**
*package.json*
```
"src": [
  "./assets/scss/**/*.scss"
],
```
*nepo.scss*
```
@import '../../../../shared/nepo/components/**/*.scss';
```