### PR TITLE
Added required dependencies to check airbnb standards.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,13 @@
     "@frctl/fractal": "^1.1.7",
     "@netzstrategen/twig-drupal-fractal-adapter": "^1.0.2",
     "del": "^3.0.0",
+    "eslint": "^5.6.1",
+    "eslint-config-airbnb": "^17.1.0",
+    "eslint-config-prettier": "^3.1.0",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-jsx-a11y": "^6.1.2",
+    "eslint-plugin-prettier": "^3.0.0",
+    "eslint-plugin-react": "^7.11.1",
     "gulp": "^4.0.0",
     "gulp-autoprefixer": "^4.0.0",
     "gulp-clean-css": "^3.7.0",
@@ -28,6 +35,7 @@
     "gulp-uglify-es": "^0.1.4",
     "minimist": "^1.2.0",
     "node-sass-magic-importer": "^5.2.0",
+    "prettier": "^1.14.3",
     "sassdoc": "^2.3.0",
     "stylelint": "^8.4.0",
     "stylelint-order": "^0.8.0",
@@ -68,5 +76,7 @@
     "test": "mocha"
   },
   "author": "netzstrategen <hallo@netzstrategen.com>",
-  "homepage": "http://www.netzstrategen.com"
+  "homepage": "http://www.netzstrategen.com",
+  "repository": "https://github.com/netzstrategen/gulp-task-collection",
+  "license": " GPL-3.0-or-later"
 }


### PR DESCRIPTION
If we want to start using the airbnb standards we need to install the required dependecies somehow. this is just an idea about where to put them. 