### PR TITLE
Added task to copy font files to dist.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,15 @@ Commonly used Gulp tasks shared across projects.
 
 ## Available commands
 
-- `gulp`: Default task runs (in order) `fractal:start`, `images`, `styles`, `scripts` and then watches for changes
-- `gulp build`: Build assets (`images`, `styles`, `scripts`)
+- `gulp`: Default task runs (in order) `fractal:start`, `fonts`, `images`, `styles`, `scripts` and then watches for changes
+- `gulp build`: Build assets (`fonts`, `images`, `styles`, `scripts`)
 - `gulp build:production`: Build production-ready assets
 
 
 - `gulp clean`: Clean `/dist` folder
 - `gulp styles` and `gulp styles:production`: Sass compilation
 - `gulp scripts` and `gulp scripts:production`: JS compilation
+- `gulp fonts`: Copy fonts to `/dist` folder
 - `gulp images`: Image compression
 - `gulp fractal:start`: Start Fractal server (if config path exists in `package.json`)
 - `gulp fractal:build`: Build static version of Fractal project

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = function (gulp) {
   let tasks = [
     'clean',
     typeof(pkg.gulpPaths.fractalConfig) === 'undefined' ? '' : 'fractal',
+    'fonts',
     'images',
     'scripts',
     'styles',

--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
   "gulpPaths": {
     "fractalConfig": "./fractal.config.js",
     "destDir": "./dist",
+    "fonts": {
+      "src": "./assets/fonts/**/*.{eot,svg,ttf,woff,woff2}",
+      "dest": "./dist/fonts"
+    },
     "images": {
       "src": "./assets/img/**/*.{jpg,jpeg,png,gif,svg}",
       "dest": "./dist/img"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netzstrategen/gulp-task-collection",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "title": "Gulp task collection",
   "description": "A collection of gulp tasks.",
   "main": "index.js",

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -3,6 +3,7 @@
 module.exports = (gulp, $, pkg) => {
   // @task: Build all static assets.
   gulp.task('build', gulp.series('clean', gulp.parallel(
+    'fonts',
     'images',
     'scripts',
     'styles'
@@ -10,6 +11,7 @@ module.exports = (gulp, $, pkg) => {
 
   // @task: Build and minify all static assets.
   gulp.task('build:production', gulp.series('clean', gulp.parallel(
+    'fonts',
     'images',
     'scripts:production',
     'styles:production'

--- a/tasks/default.js
+++ b/tasks/default.js
@@ -5,6 +5,7 @@ module.exports = (gulp, $, pkg) => {
   const watch = (callback) => {
     // Fractal automatically detects existing server instance.
     $.livereload.listen();
+    gulp.watch(pkg.gulpPaths.fonts.src, gulp.series('fonts'));
     gulp.watch(pkg.gulpPaths.images.src, gulp.series('images'));
     gulp.watch(pkg.gulpPaths.styles.src, gulp.series('styles'));
     gulp.watch(pkg.gulpPaths.scripts.src, gulp.series('scripts'));
@@ -16,6 +17,7 @@ module.exports = (gulp, $, pkg) => {
 
   let defaultTasks = [
     typeof(pkg.gulpPaths.fractalConfig) === 'undefined' ? '' : 'fractal:start',
+    'fonts',
     'images',
     'styles',
     'scripts'

--- a/tasks/fonts.js
+++ b/tasks/fonts.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = (gulp, $, pkg) => {
+  // @task: Copy fonts to dist.
+  const task = () => {
+    return gulp.src(pkg.gulpPaths.fonts.src)
+      .pipe(gulp.dest(pkg.gulpPaths.fonts.dest));
+  };
+
+  gulp.task('fonts', task);
+};


### PR DESCRIPTION
### Description
- At the moment, font files are not copied to the standard `dist` directory. To reference them in CSS, I would have to point to the `assets` directory which isn't ideal