### PR TITLE
Fixed image URLs in precompiled external CSS are not found.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netzstrategen/gulp-task-collection",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "title": "Gulp task collection",
   "description": "A collection of gulp tasks.",
   "license": "MIT",

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -46,15 +46,15 @@ module.exports = (gulp, $, pkg) => {
         }),
         outputStyle: options.outputStyle
       }).on('error', reportError))
-      .pipe($.cssUrlCustomHash({
-        targetFileType: ['jpe?g', 'png', 'webp', 'svg', 'gif', 'ico', 'otf', 'ttf', 'eot', 'woff2?'],
-      }))
       .pipe($.autoprefixer())
       .pipe($.if(options.sourcemaps, $.sourcemaps.write()))
       .pipe($.if(options.production, $.replace(copyrightPlaceholder, copyrightNotice)))
       .pipe($.if(options.production, $.cleanCss(cleanCssOptions)))
       .pipe($.if(options.production, $.rename({ suffix: '.min' })))
       .pipe($.if(options.concat, $.concat(pkg.title.toLowerCase().replace(/[^a-z]/g,'') + '.css')))
+      .pipe($.cssUrlCustomHash({
+        targetFileType: ['jpe?g', 'png', 'webp', 'svg', 'gif', 'ico', 'otf', 'ttf', 'eot', 'woff2?'],
+      }))
       .pipe(gulp.dest(pkg.gulpPaths.styles.dest))
       .pipe($.livereload());
   };


### PR DESCRIPTION
### Problem
- When concatenating e.g. the PhotoSwipe default-skin CSS into the aggregate, then the gulp-css-url-custom-hash package does not find the referenced images, because it attempts to find them in the source directory (usually "assets") instead of the compiled destination folder (usually "dist").

### Proposed solution
1. Move the url hashing later in the pipeline, right before the CSS gets written out.