### PR TITLE
Added file access and modification time to gulp generated assets.  

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netzstrategen/gulp-task-collection",
-  "version": "2.0.0",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8776,6 +8776,15 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "gulp-touch-cmd": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/gulp-touch-cmd/-/gulp-touch-cmd-0.0.1.tgz",
+      "integrity": "sha1-c669BA9cv79Wegbj/beXbvD7iMw=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "through2": "^2.0.3"
       }
     },
     "gulp-uglify-es": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "gulp-sass-glob": "^1.0.8",
     "gulp-sourcemaps": "^2.6.0",
     "gulp-stylelint": "^6.0.0",
+    "gulp-touch-cmd": "0.0.1",
     "gulp-uglify-es": "^0.1.4",
     "minimist": "^1.2.0",
     "node-sass-magic-importer": "^5.2.0",

--- a/tasks/fonts.js
+++ b/tasks/fonts.js
@@ -1,13 +1,11 @@
 'use strict';
 
-const touch = require('gulp-touch-cmd');
-
 module.exports = (gulp, $, pkg) => {
   // @task: Copy fonts to dist.
   const task = () => {
     return gulp.src(pkg.gulpPaths.fonts.src)
-      .pipe(gulp.dest(pkg.gulpPaths.fonts.dest));
-      .pipe(touch());
+      .pipe(gulp.dest(pkg.gulpPaths.fonts.dest)),
+      .pipe($.touchCmd());
   };
 
   gulp.task('fonts', task);

--- a/tasks/fonts.js
+++ b/tasks/fonts.js
@@ -1,10 +1,13 @@
 'use strict';
 
+const touch = require('gulp-touch-cmd');
+
 module.exports = (gulp, $, pkg) => {
   // @task: Copy fonts to dist.
   const task = () => {
     return gulp.src(pkg.gulpPaths.fonts.src)
       .pipe(gulp.dest(pkg.gulpPaths.fonts.dest));
+      .pipe(touch());
   };
 
   gulp.task('fonts', task);

--- a/tasks/fonts.js
+++ b/tasks/fonts.js
@@ -4,7 +4,7 @@ module.exports = (gulp, $, pkg) => {
   // @task: Copy fonts to dist.
   const task = () => {
     return gulp.src(pkg.gulpPaths.fonts.src)
-      .pipe(gulp.dest(pkg.gulpPaths.fonts.dest)),
+      .pipe(gulp.dest(pkg.gulpPaths.fonts.dest))
       .pipe($.touchCmd());
   };
 

--- a/tasks/images.js
+++ b/tasks/images.js
@@ -1,6 +1,9 @@
 'use strict';
 
 module.exports = (gulp, $, pkg) => {
+
+  const touch = require('gulp-touch-cmd');
+
   // @task: Process and minify images.
   const task = () => {
     return gulp.src(pkg.gulpPaths.images.src)
@@ -11,6 +14,7 @@ module.exports = (gulp, $, pkg) => {
         $.imagemin.svgo({ plugins: [{ cleanupIDs: false }] })
       ]))
       .pipe(gulp.dest(pkg.gulpPaths.images.dest));
+      .pipe(touch());
   };
 
   gulp.task('images', task);

--- a/tasks/images.js
+++ b/tasks/images.js
@@ -1,9 +1,6 @@
 'use strict';
 
 module.exports = (gulp, $, pkg) => {
-
-  const touch = require('gulp-touch-cmd');
-
   // @task: Process and minify images.
   const task = () => {
     return gulp.src(pkg.gulpPaths.images.src)
@@ -13,8 +10,8 @@ module.exports = (gulp, $, pkg) => {
         $.imagemin.optipng({ optimizationLevel: 5 }),
         $.imagemin.svgo({ plugins: [{ cleanupIDs: false }] })
       ]))
-      .pipe(gulp.dest(pkg.gulpPaths.images.dest));
-      .pipe(touch());
+      .pipe(gulp.dest(pkg.gulpPaths.images.dest)),
+      .pipe($.touchCmd());
   };
 
   gulp.task('images', task);

--- a/tasks/images.js
+++ b/tasks/images.js
@@ -10,7 +10,7 @@ module.exports = (gulp, $, pkg) => {
         $.imagemin.optipng({ optimizationLevel: 5 }),
         $.imagemin.svgo({ plugins: [{ cleanupIDs: false }] })
       ]))
-      .pipe(gulp.dest(pkg.gulpPaths.images.dest)),
+      .pipe(gulp.dest(pkg.gulpPaths.images.dest))
       .pipe($.touchCmd());
   };
 

--- a/tasks/scripts.js
+++ b/tasks/scripts.js
@@ -1,9 +1,6 @@
 'use strict';
 
 module.exports = (gulp, $, pkg) => {
-
-  const touch = require('gulp-touch-cmd');
-
   // @task: Build JS from components.
   const task = (args = {}) => {
     const options = Object.assign($.minimist(process.argv.slice(2), {
@@ -24,7 +21,7 @@ module.exports = (gulp, $, pkg) => {
       .pipe($.if(options.production, $.uglifyEs.default()))
       .pipe($.if(options.production, $.rename({ suffix: '.min' })))
       .pipe(gulp.dest(pkg.gulpPaths.scripts.dest))
-      .pipe(touch())
+      .pipe($.touchCmd())
       .pipe($.livereload());
   };
 

--- a/tasks/scripts.js
+++ b/tasks/scripts.js
@@ -1,6 +1,9 @@
 'use strict';
 
 module.exports = (gulp, $, pkg) => {
+
+  const touch = require('gulp-touch-cmd');
+
   // @task: Build JS from components.
   const task = (args = {}) => {
     const options = Object.assign($.minimist(process.argv.slice(2), {
@@ -21,6 +24,7 @@ module.exports = (gulp, $, pkg) => {
       .pipe($.if(options.production, $.uglifyEs.default()))
       .pipe($.if(options.production, $.rename({ suffix: '.min' })))
       .pipe(gulp.dest(pkg.gulpPaths.scripts.dest))
+      .pipe(touch())
       .pipe($.livereload());
   };
 

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -22,8 +22,6 @@ module.exports = (gulp, $, pkg) => {
     }
   };
 
-  const touch = require('gulp-touch-cmd');
-
   // @task: Build Sass styles from components.
   const task = (args) => {
     const options = Object.assign($.minimist(process.argv.slice(2), {
@@ -58,7 +56,7 @@ module.exports = (gulp, $, pkg) => {
         targetFileType: ['jpe?g', 'png', 'webp', 'svg', 'gif', 'ico', 'otf', 'ttf', 'eot', 'woff2?'],
       }))
       .pipe(gulp.dest(pkg.gulpPaths.styles.dest))
-      .pipe(touch())
+      .pipe($.touchCmd())
       .pipe($.livereload());
   };
 

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -22,6 +22,8 @@ module.exports = (gulp, $, pkg) => {
     }
   };
 
+  const touch = require('gulp-touch-cmd');
+
   // @task: Build Sass styles from components.
   const task = (args) => {
     const options = Object.assign($.minimist(process.argv.slice(2), {
@@ -56,6 +58,7 @@ module.exports = (gulp, $, pkg) => {
         targetFileType: ['jpe?g', 'png', 'webp', 'svg', 'gif', 'ico', 'otf', 'ttf', 'eot', 'woff2?'],
       }))
       .pipe(gulp.dest(pkg.gulpPaths.styles.dest))
+      .pipe(touch())
       .pipe($.livereload());
   };
 


### PR DESCRIPTION
Gulp version 4 added a new feature : the computed files content change in the destination folder but  the modification time does not change  accordingly. For this reason any later script on the frontend that would try to  burst cached assets according to file modification time would fail. 

This PR introduces https://github.com/bmatzner/gulp-touch-cmd  
