### PR TITLE
Updated gulp-clean-css to 4.3.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netzstrategen/gulp-task-collection",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "title": "Gulp task collection",
   "description": "A collection of gulp tasks.",
   "license": "MIT",
@@ -16,7 +16,7 @@
     "gulp": "^4.0.0",
     "gulp-autoprefixer": "^4.0.0",
     "gulp-babel": "^8.0.0",
-    "gulp-clean-css": "^3.7.0",
+    "gulp-clean-css": "^4.3.0",
     "gulp-concat": "^2.6.1",
     "gulp-css-url-custom-hash": "^0.0.5",
     "gulp-eslint": "^5.0.0",


### PR DESCRIPTION
### Ticket
- [Gulp task collection removes @font-face definitions](https://app.asana.com/0/809933051638353/1172179756456061/f)

### Description
- The `clean-css` package was sometimes removing the @font-face rules. So in some sites where the base style includes a @font-face definition but no styling references it then the the rule is removed.
- Since clean-css 4.1 the option `removeUnusedAtRules` is available which defaults to false. 