### PR TITLE
Fixed sourcemaps are not added by default for development builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Version 3.0 introduces some changes to the behavior in v2:
 - `concat` is now false by default for css and js. v2 was concatenating js, but not css. To keep this behavior, set `gulpPaths.scripts.options.concat: true` inside your project's `package.json`.
 - the `--production` flag is gone. To run a build for production environments, please use the corresponding `styles:production` and `scripts:production` tasks.
 - the `--outputStyle` flag is gone. It has been replaced by `--minify`.
-
+- as of v3.0.1, the option `--sourceMaps` is enabled in non-production mode.
 ## Authors
 
 - Fabian Marz: [fabian@netzstrategen.com](fabian@netzstrategen.com)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Commonly used Gulp tasks shared across projects.
 Option | Effect
 :--- | :---
 `--minify` | Additionally generate minified files, suffixed with `.min`. Defaults to `true` in production builds.
-`--sourcemaps` | Add source mappings to compiled files. Defaults to `true`in non-production buils.(v3.0.1)
+`--sourcemaps` | Add source mappings to compiled files. Defaults to `true` in non-production builds.
 `--fail-after-error` | See section _Continuous Integration_ below for details.
 `--concat` | Concatenate CSS/JS asset files into a single aggregate file.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Version 3.0 introduces some changes to the behavior in v2:
 - `concat` is now false by default for css and js. v2 was concatenating js, but not css. To keep this behavior, set `gulpPaths.scripts.options.concat: true` inside your project's `package.json`.
 - the `--production` flag is gone. To run a build for production environments, please use the corresponding `styles:production` and `scripts:production` tasks.
 - the `--outputStyle` flag is gone. It has been replaced by `--minify`.
-- the option `--sourceMaps` is enabled by default for development / non-production builds.
+- the option `--sourcemaps` is enabled by default for development / non-production builds.
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Commonly used Gulp tasks shared across projects.
 Option | Effect
 :--- | :---
 `--minify` | Additionally generate minified files, suffixed with `.min`. Defaults to `true` in production builds.
-`--sourcemaps` | Add source mappings to compiled files.
+`--sourcemaps` | Add source mappings to compiled files. Defaults to `true`in non-production buils.(v3.0.1)
 `--fail-after-error` | See section _Continuous Integration_ below for details.
 `--concat` | Concatenate CSS/JS asset files into a single aggregate file.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Version 3.0 introduces some changes to the behavior in v2:
 - `concat` is now false by default for css and js. v2 was concatenating js, but not css. To keep this behavior, set `gulpPaths.scripts.options.concat: true` inside your project's `package.json`.
 - the `--production` flag is gone. To run a build for production environments, please use the corresponding `styles:production` and `scripts:production` tasks.
 - the `--outputStyle` flag is gone. It has been replaced by `--minify`.
-- as of v3.0.1, the option `--sourceMaps` is enabled in non-production mode.
+- the option `--sourceMaps` is enabled by default for development / non-production builds.
+
 ## Authors
 
 - Fabian Marz: [fabian@netzstrategen.com](fabian@netzstrategen.com)

--- a/lib/registerTaskWithProductionMode.js
+++ b/lib/registerTaskWithProductionMode.js
@@ -1,9 +1,9 @@
-const productionDefaults = {
-  minify: true,
-};
-
 const developmentDefaults = {
   sourcemaps: true,
+};
+
+const productionDefaults = {
+  minify: true,
 };
 
 module.exports = (gulp, taskName, task) => {

--- a/lib/registerTaskWithProductionMode.js
+++ b/lib/registerTaskWithProductionMode.js
@@ -2,11 +2,7 @@ const productionDefaults = {
   minify: true,
 };
 
-const developmentDefaults = {
-  sourcemaps: true,
-};
-
 module.exports = (gulp, taskName, task) => {
-  gulp.task(taskName, () => task(developmentDefaults));
+  gulp.task(taskName, task);
   gulp.task(`${taskName}:production`, () => task(productionDefaults));
 }

--- a/lib/registerTaskWithProductionMode.js
+++ b/lib/registerTaskWithProductionMode.js
@@ -2,7 +2,11 @@ const productionDefaults = {
   minify: true,
 };
 
+const developmentDefaults = {
+  sourcemaps: true,
+};
+
 module.exports = (gulp, taskName, task) => {
-  gulp.task(taskName, task);
+  gulp.task(taskName, () => task(developmentDefaults));
   gulp.task(`${taskName}:production`, () => task(productionDefaults));
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netzstrategen/gulp-task-collection",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "title": "Gulp task collection",
   "description": "A collection of gulp tasks.",
   "license": "MIT",


### PR DESCRIPTION
### Ticket
[BNNCUE-4180](https://jira.stibodx.com/browse/BNNCUE-4180)

Problem
* Sourcemaps are not generated by default when compiling assets for regular development.

### Description
This change introduces a set of options similar to those used for *:production, this only affects the tasks, where the execution differs for development and production.
