### PR TITLE
Fixed missing font-face rule compiling in some build situations

### DIFF
--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -23,7 +23,21 @@ module.exports = (gulp, $, pkg) => {
   const cleanCssPluginOptions = {
     level: {
       2: {
-        all: true,
+        all: false,
+        mergeAdjacentRules: true, // controls adjacent rules merging; defaults to true
+        mergeIntoShorthands: true, // controls merging properties into shorthands; defaults to true
+        mergeMedia: true, // controls `@media` merging; defaults to true
+        mergeNonAdjacentRules: true, // controls non-adjacent rule merging; defaults to true
+        mergeSemantically: false, // controls semantic merging; defaults to false
+        overrideProperties: true, // controls property overriding based on understandability; defaults to true
+        removeEmpty: true, // controls removing empty rules and nested blocks; defaults to `true`
+        reduceNonAdjacentRules: true, // controls non-adjacent rule reducing; defaults to true
+        removeDuplicateFontRules: true, // controls duplicate `@font-face` removing; defaults to true
+        removeDuplicateMediaBlocks: true, // controls duplicate `@media` removing; defaults to true
+        removeDuplicateRules: true, // controls duplicate rules removing; defaults to true
+        removeUnusedAtRules: false, // controls unused at rule removing; defaults to false (available since 4.1.0)
+        restructureRules: false, // controls rule restructuring; defaults to false
+        skipProperties: [] // controls which properties won't be optimized, defaults to `[]` which means all will be optimized (since 4.1.0)
       }
     }
   };


### PR DESCRIPTION
### Description
- in some circumstances  the [css-clean library](https://github.com/jakubpawlowicz/clean-css#how-to-use-clean-css-api) might skip a font face declaration that is required in the minified version of the css file. 