### PR TITLE
Fixed module gulp-css-url-custom-hash could not be fetched.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "@netzstrategen/gulp-task-collection",
-  "version": "3.0.3",
+  "version": "3.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.0.3",
+      "name": "@netzstrategen/gulp-task-collection",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.9.0",
@@ -19,7 +20,7 @@
         "gulp-babel": "^8.0.0",
         "gulp-clean-css": "^4.3.0",
         "gulp-concat": "^2.6.1",
-        "gulp-css-url-custom-hash": "netzstrategen/gulp-css-url-custom-hash",
+        "gulp-css-url-custom-hash": "https://github.com/netzstrategen/gulp-css-url-custom-hash.git",
         "gulp-eslint7": "^0.3.1",
         "gulp-if": "^2.0.2",
         "gulp-imagemin": "^7.1.0",
@@ -1466,12 +1467,277 @@
         "twig": "^1.10.5"
       }
     },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/@frctl/core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@frctl/core/-/core-0.3.3.tgz",
+      "integrity": "sha512-VCW93BD6CdBVbuvGfZ9oNyAPkWbnmXXBuGKBkfnADdg9fwOXr9EBKgBmuWMaRhg25yw9ANL+/Nk9ABgGCMMNhQ==",
+      "dependencies": {
+        "@allmarkedup/fang": "^2.0.0",
+        "anymatch": "^3.1.2",
+        "bluebird": "^3.7.2",
+        "chokidar": "^3.5.1",
+        "co": "^4.6.0",
+        "fs-extra": "^9.1.0",
+        "globby": "^11.0.3",
+        "highlight.js": "^10.7.2",
+        "istextorbinary": "^5.12.0",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "marked": "^2.0.3",
+        "minimist": "^1.2.5",
+        "mixwith": "^0.1.1",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/@frctl/core/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/@frctl/core/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/@frctl/fractal": {
+      "version": "1.5.11",
+      "resolved": "https://registry.npmjs.org/@frctl/fractal/-/fractal-1.5.11.tgz",
+      "integrity": "sha512-HdCoIaqD1iRqLAF8CzvRkI2Tb98is8dKnMtzMk7juuMWCL25L3LQcmWhDJcVkRdN7vH+S3PgjKZw2jC8TjZ4QA==",
+      "dependencies": {
+        "@frctl/core": "^0.3.3",
+        "@frctl/handlebars": "^1.2.13",
+        "@frctl/mandelbrot": "^1.9.4",
+        "@frctl/web": "^0.1.10",
+        "anymatch": "^3.1.2",
+        "bluebird": "^3.7.2",
+        "chalk": "^4.1.1",
+        "chokidar": "^3.5.1",
+        "cli-table3": "^0.6.0",
+        "co": "^4.6.0",
+        "columnify": "^1.5.4",
+        "execa": "^5.0.0",
+        "fs-extra": "^9.1.0",
+        "gray-matter": "^4.0.3",
+        "handlebars": "^4.7.7",
+        "inquirer": "^7.3.3",
+        "liftoff": "^3.1.0",
+        "lodash": "^4.17.21",
+        "log-update": "^4.0.0",
+        "mime": "^2.5.2",
+        "require-all": "^3.0.0",
+        "semver": "^7.3.5",
+        "update-notifier": "^5.1.0",
+        "vinyl": "^2.2.1",
+        "vorpal": "^1.12.0"
+      },
+      "bin": {
+        "fractal": "bin/fractal.js"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/@frctl/handlebars": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/@frctl/handlebars/-/handlebars-1.2.13.tgz",
+      "integrity": "sha512-IqUwH5Yp1tS0o601IC/dzMdCaFqZe8yE8vJZYqkWRX9QJf1rnzPngBFpdsPewdLaxMZcQ/R38EMp6xM3XoiClw==",
+      "dependencies": {
+        "@frctl/core": "^0.3.3",
+        "bluebird": "^3.7.2",
+        "handlebars": "^4.7.7",
+        "lodash": "^4.17.21",
+        "promised-handlebars": "^2.0.1"
+      },
+      "peerDependencies": {
+        "@frctl/fractal": "^1.1.0"
+      }
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/@frctl/mandelbrot": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@frctl/mandelbrot/-/mandelbrot-1.9.4.tgz",
+      "integrity": "sha512-Zeu8tohZZo0OLdfawMv/SVGjT+xEc7I+C3wmxenlQlZnhohzm6FZrAO4/MV/YTrvNbysoWMdEbkNLte/h+/PCQ==",
+      "dependencies": {
+        "js-beautify": "^1.13.13",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "@frctl/fractal": ">= 1.5 < 2"
+      }
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/@frctl/web": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@frctl/web/-/web-0.1.10.tgz",
+      "integrity": "sha512-3CT4d45CXAw2iHlCdU6fSap1WZlteI8Iwje749wKE78bMBIKz5f17ig+gRzclgE8YadK+U1bjPhU5XstjQUHMw==",
+      "dependencies": {
+        "@frctl/core": "^0.3.3",
+        "anymatch": "^3.1.2",
+        "bluebird": "^3.7.2",
+        "browser-sync": "^2.26.14",
+        "chokidar": "^3.5.1",
+        "express": "^4.17.1",
+        "fs-extra": "^9.1.0",
+        "get-port": "^5.1.1",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "nunjucks": "^3.2.3",
+        "path-to-regexp": "^6.2.0",
+        "require-all": "^3.0.0",
+        "throat": "^6.0.1"
+      }
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/@frctl/web/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/@frctl/web/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@netzstrategen/fractal-twig/node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/globby": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/js-beautify": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.0.tgz",
+      "integrity": "sha512-yuck9KirNSCAwyNJbqW+BxJqJ0NLJ4PwBUzQQACl5O3qHMBXVkXb/rD0ilh/Lat/tn88zSZ+CAHOlk0DsY7GuQ==",
+      "dependencies": {
+        "config-chain": "^1.1.12",
+        "editorconfig": "^0.15.3",
+        "glob": "^7.1.3",
+        "nopt": "^5.0.0"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@netzstrategen/fractal-twig/node_modules/js-yaml": {
@@ -1485,6 +1751,66 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/marked": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
+      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
+      "bin": {
+        "marked": "bin/marked"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@netzstrategen/fractal-twig/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@netzstrategen/twig-asset": {
       "version": "1.0.1",
@@ -4620,7 +4946,7 @@
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
       "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.",
+      "deprecated": "core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
       "hasInstallScript": true
     },
     "node_modules/core-js-compat": {
@@ -8508,6 +8834,7 @@
     "node_modules/gulp-css-url-custom-hash": {
       "version": "1.0.0",
       "resolved": "git+ssh://git@github.com/netzstrategen/gulp-css-url-custom-hash.git#238503a46efbfbb336cfbb7c12ac874b9562537c",
+      "integrity": "sha512-FDyv2yu4Wb8R+hkMrou6EJZS3pKdNXZoS9fG05saPYfYqtw9OkCUWmR9FGoL3z5BibJeA2xtChJmEx1Dg3mebQ==",
       "license": "MIT",
       "dependencies": {
         "through2": "^2.0.3"
@@ -19016,6 +19343,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
       "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+      "deprecated": "This version of tar is no longer supported, and will not receive security updates. Please upgrade asap.",
       "dependencies": {
         "block-stream": "*",
         "fstream": "^1.0.12",
@@ -19619,6 +19947,7 @@
       "version": "3.3.9",
       "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
       "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+      "deprecated": "support for ECMAScript is superseded by `uglify-js` as of v3.13.0",
       "dependencies": {
         "commander": "~2.13.0",
         "source-map": "~0.6.1"
@@ -20207,6 +20536,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "bin": {
         "uuid": "bin/uuid"
       }
@@ -21014,6 +21344,7 @@
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
       "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
+      "deprecated": "Deprecated due to CVE-2021-21366 resolved in 0.5.0",
       "engines": {
         "node": ">=0.1"
       }
@@ -22325,12 +22656,222 @@
         "twig": "^1.10.5"
       },
       "dependencies": {
+        "@frctl/core": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/@frctl/core/-/core-0.3.3.tgz",
+          "integrity": "sha512-VCW93BD6CdBVbuvGfZ9oNyAPkWbnmXXBuGKBkfnADdg9fwOXr9EBKgBmuWMaRhg25yw9ANL+/Nk9ABgGCMMNhQ==",
+          "requires": {
+            "@allmarkedup/fang": "^2.0.0",
+            "anymatch": "^3.1.2",
+            "bluebird": "^3.7.2",
+            "chokidar": "^3.5.1",
+            "co": "^4.6.0",
+            "fs-extra": "^9.1.0",
+            "globby": "^11.0.3",
+            "highlight.js": "^10.7.2",
+            "istextorbinary": "^5.12.0",
+            "js-yaml": "^4.1.0",
+            "lodash": "^4.17.21",
+            "marked": "^2.0.3",
+            "minimist": "^1.2.5",
+            "mixwith": "^0.1.1",
+            "readable-stream": "^3.6.0"
+          },
+          "dependencies": {
+            "argparse": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+              "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+            },
+            "js-yaml": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+              "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+              "requires": {
+                "argparse": "^2.0.1"
+              }
+            }
+          }
+        },
+        "@frctl/fractal": {
+          "version": "1.5.11",
+          "resolved": "https://registry.npmjs.org/@frctl/fractal/-/fractal-1.5.11.tgz",
+          "integrity": "sha512-HdCoIaqD1iRqLAF8CzvRkI2Tb98is8dKnMtzMk7juuMWCL25L3LQcmWhDJcVkRdN7vH+S3PgjKZw2jC8TjZ4QA==",
+          "requires": {
+            "@frctl/core": "^0.3.3",
+            "@frctl/handlebars": "^1.2.13",
+            "@frctl/mandelbrot": "^1.9.4",
+            "@frctl/web": "^0.1.10",
+            "anymatch": "^3.1.2",
+            "bluebird": "^3.7.2",
+            "chalk": "^4.1.1",
+            "chokidar": "^3.5.1",
+            "cli-table3": "^0.6.0",
+            "co": "^4.6.0",
+            "columnify": "^1.5.4",
+            "execa": "^5.0.0",
+            "fs-extra": "^9.1.0",
+            "gray-matter": "^4.0.3",
+            "handlebars": "^4.7.7",
+            "inquirer": "^7.3.3",
+            "liftoff": "^3.1.0",
+            "lodash": "^4.17.21",
+            "log-update": "^4.0.0",
+            "mime": "^2.5.2",
+            "require-all": "^3.0.0",
+            "semver": "^7.3.5",
+            "update-notifier": "^5.1.0",
+            "vinyl": "^2.2.1",
+            "vorpal": "^1.12.0"
+          }
+        },
+        "@frctl/handlebars": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/@frctl/handlebars/-/handlebars-1.2.13.tgz",
+          "integrity": "sha512-IqUwH5Yp1tS0o601IC/dzMdCaFqZe8yE8vJZYqkWRX9QJf1rnzPngBFpdsPewdLaxMZcQ/R38EMp6xM3XoiClw==",
+          "requires": {
+            "@frctl/core": "^0.3.3",
+            "bluebird": "^3.7.2",
+            "handlebars": "^4.7.7",
+            "lodash": "^4.17.21",
+            "promised-handlebars": "^2.0.1"
+          }
+        },
+        "@frctl/mandelbrot": {
+          "version": "1.9.4",
+          "resolved": "https://registry.npmjs.org/@frctl/mandelbrot/-/mandelbrot-1.9.4.tgz",
+          "integrity": "sha512-Zeu8tohZZo0OLdfawMv/SVGjT+xEc7I+C3wmxenlQlZnhohzm6FZrAO4/MV/YTrvNbysoWMdEbkNLte/h+/PCQ==",
+          "requires": {
+            "js-beautify": "^1.13.13",
+            "lodash": "^4.17.21"
+          }
+        },
+        "@frctl/web": {
+          "version": "0.1.10",
+          "resolved": "https://registry.npmjs.org/@frctl/web/-/web-0.1.10.tgz",
+          "integrity": "sha512-3CT4d45CXAw2iHlCdU6fSap1WZlteI8Iwje749wKE78bMBIKz5f17ig+gRzclgE8YadK+U1bjPhU5XstjQUHMw==",
+          "requires": {
+            "@frctl/core": "^0.3.3",
+            "anymatch": "^3.1.2",
+            "bluebird": "^3.7.2",
+            "browser-sync": "^2.26.14",
+            "chokidar": "^3.5.1",
+            "express": "^4.17.1",
+            "fs-extra": "^9.1.0",
+            "get-port": "^5.1.1",
+            "js-yaml": "^4.1.0",
+            "lodash": "^4.17.21",
+            "nunjucks": "^3.2.3",
+            "path-to-regexp": "^6.2.0",
+            "require-all": "^3.0.0",
+            "throat": "^6.0.1"
+          },
+          "dependencies": {
+            "argparse": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+              "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+            },
+            "js-yaml": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+              "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+              "requires": {
+                "argparse": "^2.0.1"
+              }
+            }
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "anymatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+          "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
         "argparse": {
           "version": "1.0.10",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
           "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
           "requires": {
             "sprintf-js": "~1.0.2"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "globby": {
+          "version": "11.0.4",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+          "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.1.1",
+            "ignore": "^5.1.4",
+            "merge2": "^1.3.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "gray-matter": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+          "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+          "requires": {
+            "js-yaml": "^3.13.1",
+            "kind-of": "^6.0.2",
+            "section-matter": "^1.0.0",
+            "strip-bom-string": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "highlight.js": {
+          "version": "10.7.3",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+          "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
+        },
+        "js-beautify": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.0.tgz",
+          "integrity": "sha512-yuck9KirNSCAwyNJbqW+BxJqJ0NLJ4PwBUzQQACl5O3qHMBXVkXb/rD0ilh/Lat/tn88zSZ+CAHOlk0DsY7GuQ==",
+          "requires": {
+            "config-chain": "^1.1.12",
+            "editorconfig": "^0.15.3",
+            "glob": "^7.1.3",
+            "nopt": "^5.0.0"
           }
         },
         "js-yaml": {
@@ -22341,6 +22882,45 @@
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
           }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "marked": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
+          "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA=="
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -27953,7 +28533,7 @@
     },
     "gulp-css-url-custom-hash": {
       "version": "git+ssh://git@github.com/netzstrategen/gulp-css-url-custom-hash.git#238503a46efbfbb336cfbb7c12ac874b9562537c",
-      "from": "gulp-css-url-custom-hash@netzstrategen/gulp-css-url-custom-hash",
+      "from": "gulp-css-url-custom-hash@https://github.com/netzstrategen/gulp-css-url-custom-hash.git",
       "requires": {
         "through2": "^2.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netzstrategen/gulp-task-collection",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "title": "Gulp task collection",
   "description": "A collection of gulp tasks.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "gulp-babel": "^8.0.0",
     "gulp-clean-css": "^4.3.0",
     "gulp-concat": "^2.6.1",
-    "gulp-css-url-custom-hash": "netzstrategen/gulp-css-url-custom-hash",
+    "gulp-css-url-custom-hash": "https://github.com/netzstrategen/gulp-css-url-custom-hash.git",
     "gulp-eslint7": "^0.3.1",
     "gulp-if": "^2.0.2",
     "gulp-imagemin": "^7.1.0",


### PR DESCRIPTION
### Description
- Running `$ npm ci` failed as it ran into a permission error (public key) when trying to fetch this module. This seems to be caused as it tries to access via SSH (even the repo is public) and fails.
