### PR TITLE
Fixed asset hash is not added due to race condition.

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -2,6 +2,8 @@
 
 module.exports = (gulp, $, pkg) => {
   const buildTasks = [
+    'clean',
+    'images',
     typeof(pkg.gulpPaths.fonts) === 'undefined' ? '' : 'fonts',
     typeof(pkg.gulpPaths.icons) === 'undefined' ? '' : 'icons',
     typeof(pkg.gulpPaths.scripts) === 'undefined' ? '' : 'scripts',
@@ -9,13 +11,11 @@ module.exports = (gulp, $, pkg) => {
   ];
 
   // @task: Build all static assets.
-  gulp.task('build', gulp.series(
-    'clean',
-    'images',
-    gulp.parallel(buildTasks.filter(Boolean))
-  ));
+  gulp.task('build', gulp.series(buildTasks.filter(Boolean)));
 
   const productionBuildTasks = [
+    'clean',
+    'images',
     typeof(pkg.gulpPaths.fonts) === 'undefined' ? '' : 'fonts',
     typeof(pkg.gulpPaths.icons) === 'undefined' ? '' : 'icons',
     typeof(pkg.gulpPaths.scripts) === 'undefined' ? '' : 'scripts:production',
@@ -23,9 +23,5 @@ module.exports = (gulp, $, pkg) => {
   ];
 
   // @task: Build and minify all static assets.
-  gulp.task('build:production', gulp.series(
-    'clean',
-    'images',
-    gulp.parallel(productionBuildTasks.filter(Boolean))
-  ));
+  gulp.task('build:production', gulp.series(productionBuildTasks.filter(Boolean)));
 }

--- a/tasks/default.js
+++ b/tasks/default.js
@@ -23,6 +23,7 @@ module.exports = (gulp, $, pkg) => {
   };
 
   let defaultTasks = [
+    'images',
     typeof(pkg.gulpPaths.fonts) === 'undefined' ? '' : 'fonts',
     typeof(pkg.gulpPaths.icons) === 'undefined' ? '' : 'icons',
     typeof(pkg.gulpPaths.styles) === 'undefined' ? '' : 'styles',
@@ -31,5 +32,5 @@ module.exports = (gulp, $, pkg) => {
   defaultTasks = defaultTasks.filter(Boolean);
 
   // @task: Default. Build and watch for changes.
-  gulp.task('default', gulp.series('images', gulp.parallel(defaultTasks), watch));
+  gulp.task('default', gulp.series(defaultTasks, watch));
 }


### PR DESCRIPTION
### Description
- The styles task scans the css files for linked images/icons and appends a hash to it to ensure browsers invalidate caches. Since the icons and style task run in parallel the task fails due to a race condition.
