### PR TITLE
Fix compilation for development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@netzstrategen/gulp-task-collection",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@netzstrategen/gulp-task-collection",
-      "version": "4.1.2",
+      "version": "4.1.3",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netzstrategen/gulp-task-collection",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "title": "Gulp task collection",
   "description": "A collection of gulp tasks.",
   "license": "MIT",

--- a/tasks/scripts.js
+++ b/tasks/scripts.js
@@ -14,45 +14,45 @@ module.exports = (gulp, $, pkg) => {
 
     return gulp
       .src(pkg.gulpPaths.scripts.src)
-      .pipe($.if(!options['fail-after-error'], $.plumber()))
+      .pipe($.if(!options["fail-after-error"], $.plumber()))
       .pipe($.if(!options.concat, $.named()))
       .pipe(
         $.if(
           !options.concat,
-          $.rename(path => (tmp[path.basename] = path))
-        )
+          $.rename((path) => (tmp[path.basename] = path)),
+        ),
       )
       .pipe(
         $.webpackStream(
           {
             ...webpackConfig,
             optimization: {
-              minimize: false
-            }
+              minimize: false,
+            },
           },
-          $.webpack
-        )
+          $.webpack,
+        ),
       )
-      .pipe($.rename(path => (path.dirname = tmp[path.basename].dirname)))
+      .pipe($.rename((path) => (path.dirname = tmp[path.basename].dirname)))
       .pipe(gulp.dest(pkg.gulpPaths.scripts.dest))
-      .pipe($.if(!options.concat && options.minify, $.named()))
+      .pipe($.if(!options.concat, $.named()))
       .pipe(
         $.if(
-          !options.concat && options.minify,
-          $.rename(path => (tmp[path.basename] = path))
-        )
+          !options.concat,
+          $.rename((path) => (tmp[path.basename] = path)),
+        ),
       )
       .pipe($.if(options.minify, $.webpackStream(webpackConfig, $.webpack)))
       .pipe(
         $.if(
-          !options.concat && options.minify,
-          $.rename(path => {
-            path.dirname = tmp[path.basename]?.dirname || '.';
+          !options.concat,
+          $.rename((path) => {
+            path.dirname = tmp[path.basename]?.dirname || ".";
             path.basename = `${path.basename}.min`;
-          })
-        )
+          }),
+        ),
       )
-      .pipe($.if(options.minify, gulp.dest(pkg.gulpPaths.scripts.dest)))
+      .pipe($.if(!options.concat, gulp.dest(pkg.gulpPaths.scripts.dest)))
       .pipe($.touchCmd());
   };
 


### PR DESCRIPTION
Fixed issue when compiling on development mode. The watch task didn't run the compilation of the `.min.js` files.
The generation of the file has been added without minimizing the content.