### PR TITLE
Added optional chaining parser for old browser compatibility

### DIFF
--- a/lib/webpack.config.js
+++ b/lib/webpack.config.js
@@ -35,7 +35,12 @@ module.exports = {
           {
             loader: 'babel-loader',
             options: {
-              presets: ['@babel/preset-env'],
+              presets: [
+                '@babel/preset-env',
+              ],
+              plugins: [
+                "@babel/plugin-proposal-optional-chaining",
+              ]
             }
           }
         ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@netzstrategen/gulp-task-collection",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@netzstrategen/gulp-task-collection",
-      "version": "4.1.3",
+      "version": "4.1.4",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,9 @@
         "vinyl-named": "^1.1.0",
         "webpack": "^5.75.0",
         "webpack-stream": "^7.0.0"
+      },
+      "devDependencies": {
+        "@babel/plugin-proposal-optional-chaining": "^7.20.7"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -660,12 +663,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-optional-chaining": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.18.9.tgz",
-      "integrity": "sha512-v5nwt4IqBXihxGsW2QmCWMDS3B3bzGIk/EQVZz2ei7f3NJl8NzAJVvUmpDW5q1CRNY+Beb/k58UAH1Km1N411w==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.20.7.tgz",
+      "integrity": "sha512-T+A7b1kfjtRM51ssoOfS1+wbyCVqorfyZhT99TvxxLMirPShD8CzKMRepMlCBGM5RpHMbn8s+5MMHnPstJH6mQ==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.18.9",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.18.9",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3"
       },
       "engines": {
@@ -14884,12 +14887,12 @@
       }
     },
     "@babel/plugin-proposal-optional-chaining": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.18.9.tgz",
-      "integrity": "sha512-v5nwt4IqBXihxGsW2QmCWMDS3B3bzGIk/EQVZz2ei7f3NJl8NzAJVvUmpDW5q1CRNY+Beb/k58UAH1Km1N411w==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.20.7.tgz",
+      "integrity": "sha512-T+A7b1kfjtRM51ssoOfS1+wbyCVqorfyZhT99TvxxLMirPShD8CzKMRepMlCBGM5RpHMbn8s+5MMHnPstJH6mQ==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.18.9",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.18.9",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netzstrategen/gulp-task-collection",
-  "version": "4.1.3-v2",
+  "version": "4.1.3",
   "title": "Gulp task collection",
   "description": "A collection of gulp tasks.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netzstrategen/gulp-task-collection",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "title": "Gulp task collection",
   "description": "A collection of gulp tasks.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netzstrategen/gulp-task-collection",
-  "version": "4.1.3",
+  "version": "4.1.3-v2",
   "title": "Gulp task collection",
   "description": "A collection of gulp tasks.",
   "license": "MIT",
@@ -10,6 +10,7 @@
   "dependencies": {
     "@babel/core": "^7.20.5",
     "@babel/preset-env": "^7.20.2",
+    "@babel/plugin-proposal-optional-chaining": "^7.20.7",
     "@netzstrategen/twig-asset": "^1.0.1",
     "del": "^3.0.0",
     "gulp": "^4.0.2",


### PR DESCRIPTION
### Ticket
- [Bug: Product Finder not working on ipad](https://app.asana.com/0/1141864033797921/1203800181886942)

### Description
- With iPads and iPhones with iOS versions previous to 14, `?.` opitional chaining does not work. This was causing problems on Hauraton.
- iOS version 13 is still maintaned, so it's good to add this to have more compatibility.
